### PR TITLE
adds $bootstrap_ipxe_url param

### DIFF
--- a/manifests/pxe.pp
+++ b/manifests/pxe.pp
@@ -7,8 +7,9 @@
 # be set properly for all the dhcp, pxe, and ipv4_nat subclasses.
 
 class pe_razor_complete::pxe (
-  $ipxe_url        = $pe_razor_complete::ipxe_url,
-  $tftp_port_range = $pe_razor_complete::tftp_port_range,
+  $ipxe_url           = $pe_razor_complete::ipxe_url,
+  $bootstrap_ipxe_url = "https://${::facts['fqdn']}:8151/api/microkernel/bootstrap?nic_max=1&http_port=8150",
+  $tftp_port_range    = $pe_razor_complete::tftp_port_range,
 ) inherits pe_razor_complete {
 
   # Enable the dnsmasq tftp server, and aim it at /var/lib/tftpboot for files.
@@ -38,7 +39,7 @@ class pe_razor_complete::pxe (
   # The bootstrap is static, but Razor likes to be the one to craft it.
   staging::file { 'bootstrap.ipxe':
     target      => '/var/lib/tftpboot/bootstrap.ipxe',
-    source      => "https://${::facts['fqdn']}:8151/api/microkernel/bootstrap?nic_max=1&http_port=8150",
+    source      => $bootstrap_ipxe_url,
     curl_option => '--insecure',
     require     => [ File['/var/lib/tftpboot'], Class['pe_razor'] ],
   }


### PR DESCRIPTION
@ktreese,
I'm hoping this will allow me to overwrite the bootstrap url in order to get around authentication that is causing a 401 Access Denied when curling the bootstrap.ipxe from a Razor server that has RBAC with Shiro enabled. The idea is that I would overwrite it on my end with "localhost" instead of fqdn which will then allow me to download the file. The problem then becomes the URL embedded in the ipxe file is wrong (it points to localhost instead of the fqdn of the Razor server), this will cause PXE operations to fail. My solution to this is to then sed the file as follows: `sed 's/localhost/fqdn_of_my_server/'`